### PR TITLE
add --output k8s-auth option to whoami

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1847,6 +1847,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtokens"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fb4c5f203abfb17d5f30a9f8e44c91c222fe5dcff9d6f57090167c4cfc22b70"
+dependencies = [
+ "base64 0.20.0",
+ "pem",
+ "regex",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "k8s-openapi"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2337,6 +2352,7 @@ dependencies = [
  "hex",
  "inquire",
  "itertools",
+ "jsonwebtokens",
  "k8s-openapi",
  "kube",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,4 @@ reqwest = { version = "0.12.4", features = ["json"] }
 time = "0.3.36"
 kube = { version = "0.83.0", features = ["admission", "client", "derive", "runtime"] }
 k8s-openapi = { version = "0.18.0", features = ["v1_26", "schemars"] }
+jsonwebtokens = "1.2.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
-use crate::models::artifact;
 use crate::version;
+use crate::{models::artifact, whoami};
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::{value_parser, Arg, ArgMatches, Command};
 use clap_complete::Shell;
@@ -179,6 +179,15 @@ pub fn command() -> Command {
         )
         .subcommand(Command::new("whoami")
             .about("Display information about the currently logged in user")
+            .arg(
+                Arg::new("output")
+                            .long("output")
+                            .short('o')
+                            .help("Output format")
+                            .value_parser(value_parser!(whoami::Output))
+                            .default_value("default")
+                            .required(false),
+            )
         )
         .arg(
             Arg::new("verbosity")

--- a/src/whoami.rs
+++ b/src/whoami.rs
@@ -94,11 +94,11 @@ fn k8s_auth(token_repository: &TokenRepository) -> Result<String, Error> {
         "apiVersion": "client.authentication.k8s.io/v1beta1",
         "spec": {},
         "status": {
-            "expirationTimestamp": match claims {
+            "expirationTimestamp": (match claims {
                 Some(claims) => NaiveDateTime::from_timestamp_opt(claims.exp, 0).map(|dt| dt.and_utc()),
                 _ => None,
-            },
-            "token": token,
+            }).context("unable to set expiration timestamp")?,
+            "token": token.context("missing token")?,
         },
     })
     .to_string())

--- a/src/whoami.rs
+++ b/src/whoami.rs
@@ -1,46 +1,105 @@
-use anyhow::Error;
-use clap::ArgMatches;
-
+use crate::auth::{AuthToken, TokenRepository};
 use crate::{
     cli::P6mEnvironment,
     login::update_token,
     models::openid::{OpenIdDiscoveryDocument, UserInfo},
 };
-use crate::auth::{TokenRepository, AuthToken};
+use anyhow::{Context, Error};
+use chrono::NaiveDateTime;
+use clap::ArgMatches;
+use jsonwebtokens::raw::{self, TokenSlices};
+use serde::Deserialize;
 
-pub async fn execute(environment: P6mEnvironment, _matches: &ArgMatches) -> Result<(), Error> {
+#[derive(clap::ValueEnum, Clone, Debug, PartialEq)]
+pub enum Output {
+    Default,
+    Json,
+    K8sAuth,
+}
+
+pub async fn execute(environment: P6mEnvironment, matches: &ArgMatches) -> Result<(), Error> {
     let token_repository = TokenRepository::new(&environment)?;
     let access_token = token_repository.read_token(AuthToken::Access)?;
     let refresh_token = token_repository.read_token(AuthToken::Refresh)?;
 
+    let output = matches
+        .try_get_one("output")
+        .unwrap_or(Some(&Output::Default));
+
     let openid_configuration =
         OpenIdDiscoveryDocument::discover(environment.domain.clone()).await?;
 
-
     if let Some(access_token) = access_token {
         let info =
-            match UserInfo::request(openid_configuration.userinfo_endpoint.clone(), access_token).await {
-                Ok(info) => info,
-                Err(_) => match update_token(
-                    &openid_configuration,
-                    &environment,
-                    refresh_token,
-                )
+            match UserInfo::request(openid_configuration.userinfo_endpoint.clone(), access_token)
                 .await
-                {
-                    Ok(token_info) => {
-                        UserInfo::request(
-                            openid_configuration.userinfo_endpoint,
-                            token_info.access_token.unwrap(),
-                        )
-                        .await?
+            {
+                Ok(info) => info,
+                Err(_) => {
+                    match update_token(&openid_configuration, &environment, refresh_token).await {
+                        Ok(token_info) => {
+                            UserInfo::request(
+                                openid_configuration.userinfo_endpoint,
+                                token_info.access_token.unwrap(),
+                            )
+                            .await?
+                        }
+                        Err(e) => return Err(e),
                     }
-                    Err(e) => return Err(e),
-                },
+                }
             };
-        println!("{}", serde_json::to_string_pretty(&info)?);
+        println!(
+            "{}",
+            match output {
+                Some(Output::K8sAuth) => k8s_auth(&token_repository)?,
+                Some(Output::Json) => serde_json::to_string_pretty(&info)?,
+                None | Some(Output::Default) => format!(
+                    "Logged in as: {}",
+                    info.email.context("missing email on access token")?
+                ),
+            }
+        );
     } else {
-        println!("You are not logged in. Please run `p6m login` to log in.");
+        return Err(anyhow::anyhow!(
+            "You are not logged in. Please run `p6m login` to log in."
+        ));
     }
     Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct Claims {
+    pub exp: i64,
+}
+
+fn k8s_auth(token_repository: &TokenRepository) -> Result<String, Error> {
+    let token = token_repository.read_token(AuthToken::Access)?;
+
+    let claims = match token.clone() {
+        Some(token) => {
+            let TokenSlices { claims, .. } =
+                raw::split_token(&token).context("unable to split token")?;
+            Some(
+                serde_json::from_value::<Claims>(
+                    raw::decode_json_token_slice(claims).context("unable to decode token")?,
+                )
+                .context("unable to parse token")?,
+            )
+        }
+        None => None,
+    };
+
+    Ok(serde_json::json!({
+        "kind": "ExecCredential",
+        "apiVersion": "client.authentication.k8s.io/v1beta1",
+        "spec": {},
+        "status": {
+            "expirationTimestamp": match claims {
+                Some(claims) => NaiveDateTime::from_timestamp_opt(claims.exp, 0).map(|dt| dt.and_utc()),
+                _ => None,
+            },
+            "token": token,
+        },
+    })
+    .to_string())
 }


### PR DESCRIPTION
Extending `whoami` to output a token that is `~/.kube/config` friendly. 

The goal is to swap out `aws eks get-token` and the usage of `aws eks update-kubeconfig` in favor of p6m Auth0 creds.

```
p6m whoami
Logged in as: 182810239@users.noreply.github.com
```

```
p6m whoami --output default
Logged in as: 182810239@users.noreply.github.com
```

```
p6m whoami --output email
182810239@users.noreply.github.com
```

```
p6m whoami --output json
{
  "email": "182810239@users.noreply.github.com"
}
```

```
p6m whoami --output k8s-auth
{"kind":"ExecCredential","apiVersion":"client.authentication.k8s.io/v1beta1","spec":{},"status":{"expirationTimestamp":"2024-12-11T19:02:45Z","token":"eyJhb...[REDACTED-FROM-PR]..Ng"}}
```