### PR TITLE
[sso] add auth0 + kube config

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,2 +1,3 @@
 pub use token_repository::*;
+mod openid;
 mod token_repository;

--- a/src/auth/token_repository.rs
+++ b/src/auth/token_repository.rs
@@ -1,7 +1,7 @@
 use crate::cli::P6mEnvironment;
 use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
-use chrono::{format, DateTime, Duration, Utc};
+use chrono::{DateTime, Duration, Local, Utc};
 use jsonwebtokens::raw::{self, TokenSlices};
 use log::{debug, trace};
 use openid::AccessTokenResponse;
@@ -401,7 +401,10 @@ impl TokenRepository {
         let exp = DateTime::from_timestamp(claims.exp.unwrap_or(Utc::now().timestamp()), 0)
             .context("unable to parse exp claim")?;
 
-        debug!("{token_type} expiration: {exp}");
+        debug!(
+            "{token_type} expiration: {}",
+            exp.with_timezone(&Local::now().timezone())
+        );
 
         Ok(exp)
     }

--- a/src/auth/token_repository.rs
+++ b/src/auth/token_repository.rs
@@ -1,48 +1,170 @@
 use crate::cli::P6mEnvironment;
 use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
-use chrono::{DateTime, Duration, Utc};
+use chrono::{format, DateTime, Duration, Utc};
 use jsonwebtokens::raw::{self, TokenSlices};
-use log::debug;
+use log::{debug, trace};
 use openid::AccessTokenResponse;
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, fs};
+use std::{
+    collections::BTreeMap,
+    fmt::{self, Display, Formatter},
+    fs,
+};
 
 use super::openid;
 
 /// Acts as an abstraction for reading and writing tokens from disk.
 #[derive(Debug, Clone)]
 pub struct TokenRepository {
+    pub environment: P6mEnvironment,
     auth_dir: Utf8PathBuf,
     organization_id: Option<String>,
-    environment: P6mEnvironment,
     force: bool,
     scopes: Vec<String>,
+    desired_claims: Claims,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Claims {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub exp: Option<i64>,
-    #[serde(rename = "https://p6m.dev/v1/orgs")]
-    pub orgs: Option<BTreeMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub scope: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
-    #[serde(rename = "https://p6m.dev/v1/org")]
+
+    // Assertable/mergable claims
+    #[serde(
+        rename = "https://p6m.dev/v1/permission/login/kubernetes",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub login_kubernetes: Option<String>,
+    #[serde(
+        rename = "https://p6m.dev/v1/orgs",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub orgs: Option<BTreeMap<String, String>>,
+    #[serde(
+        rename = "https://p6m.dev/v1/org",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub org: Option<String>,
+
+    #[serde(
+        rename = "https://p6m.dev/v1/permission",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub permissions: Option<Vec<String>>,
+}
+
+impl Display for Claims {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(&self.clone())
+                .context("unable to dsplay claims")
+                .unwrap()
+        )
+    }
+}
+
+impl Claims {
+    pub fn assert(&self, desired_claims: &Claims) -> Result<()> {
+        debug!("asserting claims: {}", self);
+        debug!("desired_claims: {}", desired_claims);
+
+        if desired_claims.login_kubernetes.is_some()
+            && self.login_kubernetes != desired_claims.login_kubernetes
+        {
+            return Err(anyhow::anyhow!("Missing login:kubernetes"));
+        }
+
+        if desired_claims.org.is_some() && self.org != desired_claims.org {
+            return Err(anyhow::anyhow!("Missing desired org claim"));
+        }
+
+        if desired_claims.orgs.is_some() && self.orgs != desired_claims.orgs {
+            return Err(anyhow::anyhow!("Missing desired orgs claim"));
+        }
+
+        debug!("claims assertion passed");
+        Ok(())
+    }
+
+    pub fn merge(&mut self, from: Claims) {
+        if from.login_kubernetes.is_some() {
+            self.login_kubernetes = from.login_kubernetes;
+        }
+        if from.org.is_some() {
+            self.org = from.org;
+        }
+        if from.orgs.is_some() {
+            self.orgs = from.orgs;
+        }
+    }
+}
+
+impl Into<Claims> for Option<String> {
+    fn into(self) -> Claims {
+        match self {
+            None => Claims::default(),
+            Some(token) => {
+                let TokenSlices { claims, .. } = raw::split_token(&token)
+                    .context("unable to split token")
+                    .map_err(|e| {
+                        debug!("unable to split token: {e}");
+                        e
+                    })
+                    .unwrap_or(TokenSlices {
+                        header: "",
+                        claims: "",
+                        signature: "",
+                        message: "",
+                    });
+
+                serde_json::from_value::<Claims>(
+                    raw::decode_json_token_slice(claims)
+                        .context("unable to decode token")
+                        .map_err(|e| {
+                            debug!("unable to decode token: {e}");
+                            e
+                        })
+                        .unwrap_or_default(),
+                )
+                .map_err(|e| {
+                    debug!("unable to parse token: {e}");
+                    e
+                })
+                .unwrap_or_default()
+            }
+        }
+    }
 }
 
 impl TokenRepository {
+    pub const DEFAULT_SCOPES: &str = "openid email offline_access login:cli";
+
     /// Creates a [TokenRepository] given a [P6mEnvironment].
     pub fn new(environment: &P6mEnvironment) -> Result<TokenRepository> {
         let auth_dir = environment.config_dir().join("auth");
         fs::create_dir_all(&auth_dir)?;
-        Ok(TokenRepository {
+
+        let mut token_repository = TokenRepository {
             auth_dir,
             organization_id: None,
             environment: environment.clone(),
             force: false,
             scopes: vec![],
-        })
+            desired_claims: Claims::default(),
+        };
+
+        Self::DEFAULT_SCOPES.split(" ").for_each(|scope| {
+            token_repository.with_scope(scope, Claims::default());
+        });
+
+        Ok(token_repository)
     }
 
     pub fn force(mut self) -> Self {
@@ -64,6 +186,7 @@ impl TokenRepository {
             .context("unable to read claims from id token")?;
 
         let organization_id = id_claims
+            .clone()
             .orgs
             .and_then(|orgs| {
                 orgs.into_iter()
@@ -73,82 +196,121 @@ impl TokenRepository {
                     })
                     .map(|o| o.0)
             })
-            .context("missing desired organization in access token claims")?;
+            .context("missing desired organization in access token claims")
+            .map_err(|e| {
+                debug!("Unable to find organization {organization} in claims: {id_claims}",);
+                e
+            })?;
 
         self.with_organization_id(&organization_id)?;
+        self.with_scope(
+            format!("org:{}", organization_id).as_str(),
+            Claims {
+                org: Some(organization.clone()),
+                ..Default::default()
+            },
+        );
 
         Ok(())
     }
 
-    pub fn with_scope(&mut self, scope: &str) {
+    pub fn with_scope(&mut self, scope: &str, desired_claims: Claims) {
         self.scopes.push(scope.to_string());
+        self.scopes.sort();
+        self.scopes.dedup();
+        self.desired_claims.merge(desired_claims);
     }
 
-    pub async fn try_login(&mut self) -> Result<()> {
-        if self.force {
-            self.clear()?;
-            self.login().await?;
-        } else if self.should_refresh()? {
-            match self.refresh().await {
-                Ok(_) => return Ok(()),
-                Err(_) => self.login().await?,
-            };
-        }
+    pub async fn try_login(&mut self) -> Result<Self> {
+        let access_token_response = match self.force {
+            true => {
+                self.clear()?;
+                self.login("forced").await?
+            }
+            false => match self.try_refresh().await?.read_tokens().ok() {
+                Some(access_token_response) => access_token_response,
+                None => self.login("expired tokens").await?,
+            },
+        };
 
-        let granted_scopes: Vec<String> = self
-            .read_claims(AuthToken::Access)?
-            .context("unable to read claims")?
-            .scope
-            .context("missing scope claim")?
-            .split(" ")
-            .map(|s| s.to_string())
-            .collect();
+        self.assert_claims(&access_token_response, "post login")
+            .await?;
+        self.write_tokens(&access_token_response)?;
 
-        if !granted_scopes.iter().any(|s| !self.scopes.contains(s)) {
-            debug!(
-                "Desired scopes missing, re-authenticating. (granted: {}, desired: {})",
-                granted_scopes.join(" "),
-                self.scopes.join(" "),
-            );
-            self.login().await?;
-        }
-
-        Ok(())
+        Ok(self.clone())
     }
 
-    async fn login(&mut self) -> Result<Self> {
-        let mut device_code_request = openid::DeviceCodeRequest::new(&self.environment).await?;
+    pub async fn try_refresh(&mut self) -> Result<Self> {
+        let access_token_response = match (self.force, self.should_refresh()?) {
+            (true, _) => self.refresh("forced refresh").await?,
+            (_, true) => self
+                .refresh("expired tokens")
+                .await
+                .ok()
+                .unwrap_or(self.login("expired tokens").await?),
+            _ => self.read_tokens()?,
+        };
 
-        for scope in self.scopes.iter() {
-            device_code_request = device_code_request.with_scope(scope);
-        }
+        self.assert_claims(&access_token_response, "post refresh")
+            .await?;
+        self.write_tokens(&access_token_response)?;
+
+        Ok(self.clone())
+    }
+
+    async fn login(&mut self, reason: &str) -> Result<AccessTokenResponse> {
+        debug!("attempting login due to: {reason}");
+        let device_code_request = openid::DeviceCodeRequest::new(self).await?;
 
         let access_token_response = device_code_request
             .login()
             .await
-            .context("unable to exchange device code for tokens")?;
+            .context("unable to exchange device code for tokens")
+            .map_err(|e| {
+                debug!("Unable to exchange device code for tokens: {e}");
+                e
+            })?;
 
-        self.write_tokens(&access_token_response)?;
-
-        Ok(self.clone())
+        Ok(access_token_response)
     }
 
-    async fn refresh(&mut self) -> Result<Self> {
+    async fn refresh(&mut self, reason: &str) -> Result<AccessTokenResponse> {
+        debug!("attempting refresh due to: {reason}");
+
         let refresh_token = self
             .read_token(AuthToken::Refresh)
             .context("unable to read refresh token")?
-            .context("missing refresh token")?;
+            .context("missing refresh token")
+            .map_err(|e| {
+                debug!("Unable to read refresh token: {e}");
+                e
+            })?;
 
-        let device_code_request = openid::DeviceCodeRequest::new(&self.environment).await?;
+        let mut device_code_request = openid::DeviceCodeRequest::new(self).await?;
 
         let access_token_response = device_code_request
             .refresh(&refresh_token)
             .await
-            .context("unable to refresh tokens")?;
+            .context("unable to refresh tokens")
+            .map_err(|e| {
+                debug!("Unable to refresh tokens: {e}");
+                e
+            })?;
 
-        self.write_tokens(&access_token_response)?;
+        Ok(access_token_response)
+    }
 
-        Ok(self.clone())
+    async fn assert_claims(
+        &self,
+        access_token_resonse: &AccessTokenResponse,
+        reason: &str,
+    ) -> Result<()> {
+        debug!("asserting claims due to: {reason}");
+        let claims: Claims = Into::into(access_token_resonse.id_token.clone());
+        claims.assert(&self.desired_claims).map_err(|e| {
+            debug!("Claim assertion failed: {e}");
+            e
+        })
     }
 
     pub fn clear(&self) -> Result<()> {
@@ -161,7 +323,6 @@ impl TokenRepository {
     fn with_organization_id(&mut self, organization_id: &String) -> Result<()> {
         self.organization_id = Some(organization_id.clone());
         self.auth_dir = self.auth_dir.join(organization_id);
-        self.scopes.push(format!("org:{}", organization_id));
         fs::create_dir_all(&self.auth_dir)?;
         Ok(())
     }
@@ -177,7 +338,7 @@ impl TokenRepository {
             debug!("{path} does not exist");
             Ok(None)
         } else {
-            debug!("Reading {path}");
+            trace!("Reading {path}");
             Ok(Some(fs::read_to_string(path)?))
         }
     }
@@ -207,30 +368,6 @@ impl TokenRepository {
         Ok(claims)
     }
 
-    #[allow(dead_code)]
-    pub fn claim_keys(&self, token_type: AuthToken) -> Result<Vec<String>> {
-        let claims = match self
-            .read_token(token_type)
-            .context("missing token")?
-            .clone()
-        {
-            Some(token) => {
-                let TokenSlices { claims, .. } =
-                    raw::split_token(&token).context("unable to split token")?;
-
-                raw::decode_json_token_slice(claims)?
-                    .as_object()
-                    .context("unable to convert claims to object")?
-                    .keys()
-                    .map(|k| k.to_string())
-                    .collect()
-            }
-            None => vec![],
-        };
-
-        Ok(claims)
-    }
-
     pub fn is_logged_in(&self) -> bool {
         let id_token = self.read_token(AuthToken::Id).unwrap_or(None);
         let access_token = self.read_token(AuthToken::Access).unwrap_or(None);
@@ -244,11 +381,13 @@ impl TokenRepository {
     }
 
     pub fn should_refresh(&self) -> Result<bool> {
-        let id_exp = self.clone().read_expiration(AuthToken::Id)?;
-        let access_exp = self.clone().read_expiration(AuthToken::Access)?;
+        trace!("Checking if tokens should be refreshed");
 
-        let access_token_will_exp = access_exp < Utc::now() - Duration::hours(1);
-        let id_token_will_exp = id_exp < Utc::now() - Duration::hours(1);
+        let id_pre_exp = self.clone().read_expiration(AuthToken::Id)? - Duration::hours(1);
+        let access_pre_exp = self.clone().read_expiration(AuthToken::Access)? - Duration::hours(1);
+
+        let access_token_will_exp = Utc::now() > access_pre_exp;
+        let id_token_will_exp = Utc::now() > id_pre_exp;
 
         debug!("Access token expiring? {access_token_will_exp}");
         debug!("Id token expiring? {id_token_will_exp}");
@@ -268,22 +407,11 @@ impl TokenRepository {
         Ok(exp)
     }
 
-    #[allow(dead_code)]
-    pub fn has_claims(&self, token_type: AuthToken, desired_claims: &Vec<String>) -> Result<bool> {
-        let actual_claims = self.claim_keys(token_type)?;
-
-        debug!("Actual claims: {:?}", actual_claims);
-
-        Ok(desired_claims
-            .into_iter()
-            .all(|c| actual_claims.contains(c)))
-    }
-
     /// Write a token to disk.
     pub fn write_token(&self, token_type: AuthToken, token: Option<&String>) -> Result<()> {
         if let Some(token) = token {
             let path = self.token_path(token_type);
-            debug!("Writing {path}");
+            trace!("Writing {path}");
             fs::write(path, token)?;
         }
         Ok(())
@@ -295,6 +423,19 @@ impl TokenRepository {
         self.write_token(AuthToken::Id, tokens.id_token.as_ref())?;
         self.write_token(AuthToken::Refresh, tokens.refresh_token.as_ref())?;
         Ok(())
+    }
+
+    pub fn read_tokens(&self) -> Result<AccessTokenResponse> {
+        let access_token = self.read_token(AuthToken::Access)?.unwrap_or_default();
+        let id_token = self.read_token(AuthToken::Id)?.unwrap_or_default();
+        let refresh_token = self.read_token(AuthToken::Refresh)?.unwrap_or_default();
+
+        Ok(AccessTokenResponse {
+            access_token: Some(access_token),
+            id_token: Some(id_token),
+            refresh_token: Some(refresh_token),
+            ..Default::default()
+        })
     }
 
     /// The root directory where auth-related files are stored.
@@ -311,14 +452,25 @@ impl TokenRepository {
 
     pub fn to_string(&self) -> String {
         if let Some(claims) = self.read_claims(AuthToken::Id).unwrap_or(None) {
-            let detail: Vec<String> = match (claims.email.as_ref(), claims.org.as_ref()) {
-                (Some(email), Some(org)) => {
+            let detail: Vec<String> = match (
+                claims.email.as_ref(),
+                claims.org.as_ref(),
+                claims.permissions.as_ref(),
+            ) {
+                (Some(email), Some(org), permissions) => {
                     vec![
-                        format!("Organization: {}", org),
                         format!("Email: {}", email),
+                        format!("Organization: {}", org),
+                        format!(
+                            "Permissions: {}",
+                            match permissions {
+                                Some(permissions) => permissions.join(", "),
+                                None => "None".to_string(),
+                            }
+                        ),
                     ]
                 }
-                (Some(email), None) => vec![format!("Email: {}", email)],
+                (Some(email), None, _) => vec![format!("Email: {}", email)],
                 _ => vec![],
             };
 
@@ -334,6 +486,46 @@ impl TokenRepository {
             .context("unable to get claims")?
             .context("not logged in")?;
         Ok(serde_json::to_string_pretty(&claims)?)
+    }
+
+    pub async fn scope_str(&mut self) -> Result<String> {
+        // Massage scopes through with_scope before returning
+
+        let existing_scopes: Vec<String> = self
+            .read_claims(AuthToken::Access)
+            .unwrap_or(Some(Claims::default()))
+            .unwrap_or_default()
+            .scope
+            .unwrap_or(Self::DEFAULT_SCOPES.to_string())
+            .split(" ")
+            .map(|s| s.to_string())
+            .collect();
+
+        for scope in existing_scopes {
+            self.with_scope(scope.as_str(), Claims::default());
+        }
+
+        Ok(self.scopes.join(" "))
+    }
+
+    pub async fn form_data(&mut self) -> Result<Vec<(&str, String)>> {
+        let mut form: Vec<(&str, String)> = vec![];
+
+        let mut acr_values: Vec<String> = vec![];
+
+        if let Some(organization_id) = self.organization_id.clone() {
+            acr_values.push(format!("urn:auth:acr:organization-id:{}", organization_id));
+        }
+
+        for scope in self.scope_str().await?.split(" ") {
+            acr_values.push(format!("urn:auth:acr:scope:{}", scope));
+        }
+
+        if acr_values.len() > 0 {
+            form.push(("acr_values".into(), acr_values.join(" ")));
+        }
+
+        Ok(form)
     }
 }
 

--- a/src/auth/token_repository.rs
+++ b/src/auth/token_repository.rs
@@ -243,11 +243,10 @@ impl TokenRepository {
     pub async fn try_refresh(&mut self) -> Result<Self> {
         let access_token_response = match (self.force, self.should_refresh()?) {
             (true, _) => self.refresh("forced refresh").await?,
-            (_, true) => self
-                .refresh("expired tokens")
-                .await
-                .ok()
-                .unwrap_or(self.login("expired tokens").await?),
+            (_, true) => match self.refresh("expired tokens").await {
+                Ok(access_token_response) => access_token_response,
+                Err(_) => self.login("expired tokens").await?,
+            },
             _ => self.read_tokens()?,
         };
 

--- a/src/auth0/api.rs
+++ b/src/auth0/api.rs
@@ -1,0 +1,212 @@
+use anyhow::{anyhow, Context, Result};
+use url::Url;
+
+use super::types::Apps;
+
+#[derive(Debug, Clone)]
+pub struct Client {
+    base_url: Option<String>,
+    token: Option<String>,
+    client: Option<reqwest::Client>,
+}
+
+impl Client {
+    pub fn new() -> Self {
+        Self {
+            base_url: None,
+            token: None,
+            client: reqwest::Client::builder()
+                .user_agent(format!("p6m-cli/{}", env!("CARGO_PKG_VERSION")))
+                .build()
+                .ok(),
+        }
+    }
+
+    pub fn with_base_url(mut self, base_url: &String) -> Self {
+        self.base_url = Some(base_url.clone());
+        self
+    }
+
+    pub fn with_token(mut self, token: Option<String>) -> Self {
+        self.token = token.clone();
+        self
+    }
+
+    async fn authorization(&self) -> Result<String> {
+        Ok(format!(
+            "Bearer {}",
+            self.token
+                .as_ref()
+                .context("Missing token. Please run `p6m login`.")?
+        ))
+    }
+
+    pub async fn apps(&self) -> Result<Apps> {
+        Request::new(self)
+            .with_authorization(&self.authorization().await?)
+            .with_method(&reqwest::Method::GET)
+            .with_endpoint("apps")?
+            .send::<Apps>()
+            .await
+            .context("Failed to get apps")?
+            .context("Missing apps")
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Request {
+    client: Client,
+    authorization: Option<String>,
+    url: Option<String>,
+    method: Option<reqwest::Method>,
+    payload: Option<serde_json::Value>,
+    allow_conflict: Option<bool>,
+}
+
+impl Request {
+    pub fn new(client: &Client) -> Self {
+        Self {
+            client: client.clone(),
+            authorization: None,
+            url: None,
+            method: None,
+            payload: None,
+            allow_conflict: None,
+        }
+    }
+
+    pub fn with_authorization(mut self, authorization: &str) -> Self {
+        self.authorization = Some(authorization.to_string());
+        self
+    }
+
+    pub fn with_endpoint(mut self, endpoint: &str) -> Result<Self> {
+        let base_url = self
+            .client
+            .base_url
+            .as_ref()
+            .context("Base URL not found in Client")?;
+
+        let mut url =
+            Url::parse(base_url.trim_end_matches("/")).context("Failed to parse domain")?;
+
+        url.path_segments_mut()
+            .ok()
+            .context("Failed to get path segments")?
+            .extend(endpoint.split("/"));
+
+        self.url = Some(url.to_string());
+
+        Ok(self)
+    }
+
+    #[allow(dead_code)]
+    pub fn with_query(mut self, key: &str, value: &str) -> Result<Self> {
+        let url = self.url.as_ref().context("URL not found")?;
+
+        let mut url = Url::parse(url).context("Failed to parse URL")?;
+
+        url.query_pairs_mut().append_pair(key, value);
+
+        self.url = Some(url.to_string());
+
+        Ok(self)
+    }
+
+    pub fn with_method(mut self, method: &reqwest::Method) -> Self {
+        self.method = Some(method.clone());
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn with_payload(mut self, payload: &serde_json::Value) -> Self {
+        self.payload = Some(payload.clone());
+
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn with_allow_conflict(mut self, allow_conflict: bool) -> Self {
+        self.allow_conflict = Some(allow_conflict);
+        self
+    }
+
+    async fn send<T>(&self) -> Result<Option<T>>
+    where
+        T: serde::de::DeserializeOwned + std::fmt::Debug,
+    {
+        let client = self.client.client.as_ref().context("Client not found")?;
+
+        let method = self.method.as_ref().context("Method not found")?;
+
+        let url = self.url.as_ref().context("URL not found")?;
+
+        let request_builder = client.request(method.clone(), url);
+
+        let request_builder = match self.authorization.as_ref() {
+            Some(authorization) => request_builder.header("Authorization", authorization),
+            None => request_builder,
+        };
+
+        let response = match self.payload.as_ref() {
+            Some(payload) => request_builder
+                .json(payload)
+                .send()
+                .await
+                .context(format!("Failed to {} {:?} to {}", method, payload, url))?,
+            None => request_builder
+                .send()
+                .await
+                .context(format!("Failed to {} {}", method, url))?,
+        };
+
+        if let Err(error) = response.error_for_status_ref() {
+            let status = error.status().context("Missing status")?;
+
+            match (status, self.allow_conflict) {
+                (reqwest::StatusCode::CONFLICT, Some(true)) => {
+                    return Ok(None);
+                }
+                _ => {}
+            }
+
+            let body = response
+                .text()
+                .await
+                .context("Failed to get error response text")?;
+            match self.payload.as_ref() {
+                Some(payload) => {
+                    return Err(anyhow!(
+                        "{} {} with payload `{:?}` responded with status {}: {:?}",
+                        method,
+                        url,
+                        payload,
+                        status,
+                        body,
+                    ))
+                    .context(error)?;
+                }
+                None => {
+                    return Err(anyhow!(
+                        "{} {} responded with status {}: {:?}",
+                        method,
+                        url,
+                        status,
+                        body
+                    ))
+                    .context(error);
+                }
+            }
+        }
+
+        let text = response
+            .text()
+            .await
+            .context("Failed to get response text")?;
+
+        let response: T = serde_json::from_str::<T>(&text)
+            .context(format!("Failed to parse response: {}", text))?;
+
+        Ok(Some(response))
+    }
+}

--- a/src/auth0/mod.rs
+++ b/src/auth0/mod.rs
@@ -1,0 +1,4 @@
+mod api;
+mod types;
+
+pub use api::Client;

--- a/src/auth0/types.rs
+++ b/src/auth0/types.rs
@@ -1,0 +1,72 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use urlencoding::decode;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Apps(Vec<App>);
+
+impl Apps {
+    pub fn contain_scope(self, scope: &str) -> Self {
+        Self(
+            self.0
+                .into_iter()
+                .filter(|f| f.scopes.contains(&scope.to_string()))
+                .collect(),
+        )
+    }
+}
+
+impl IntoIterator for Apps {
+    type Item = App;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct App {
+    pub name: String,
+    pub org: Option<String>,
+    pub client_id: String,
+    pub url: String,
+    pub origins: Vec<String>,
+    pub scopes: Vec<String>,
+}
+
+impl App {
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    pub fn url(&self) -> String {
+        self.url.clone()
+    }
+
+    pub fn org(&self) -> Option<String> {
+        self.org.clone()
+    }
+
+    pub fn certificate_authority(&self) -> Result<String> {
+        let certificate_authority = self
+            .origins
+            .iter()
+            .find(|origin| origin.starts_with("https://meta.p6m.dev/certificate-authority"))
+            .map(|origin| {
+                url::Url::parse(origin)
+                    .context("unalbe to parse url")
+                    .map(|u| Some(u.fragment()?.to_string()))
+                    .context("unable to extract fragment")
+            })
+            .context("unable to find certificate authority")?
+            .context("missing certificate authority")?;
+
+        Ok(
+            decode(certificate_authority.context("missing ca")?.as_str())
+                .context("unable to decode ca")?
+                .to_string(),
+        )
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use crate::check::Ecosystem;
-use crate::version;
-use crate::{models::artifact, whoami};
+use crate::models::artifact;
+use crate::{version, whoami};
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::{value_parser, Arg, ArgMatches, Command};
 use clap_complete::Shell;
@@ -184,6 +184,9 @@ pub fn command() -> Command {
             .subcommand(Command::new("azure")
                 .about("Only configure SSO for Azure")
             )
+            .subcommand(Command::new("auth0")
+                .about("Only configure SSO for Auth0")
+            )
         )
         .subcommand(Command::new("login")
             .about("Login to p6m services")
@@ -244,6 +247,7 @@ impl Environment {}
 #[derive(Debug, Clone)]
 pub struct P6mEnvironment {
     pub config_dir: Utf8PathBuf,
+    pub kube_dir: Utf8PathBuf,
 
     // Auth0
     pub domain: String,
@@ -265,6 +269,7 @@ impl P6mEnvironment {
                 println!("Using development environment");
                 Self {
                     config_dir: home_dir.join(".p6m-dev"),
+                    kube_dir: home_dir.join(".kube"),
                     domain: "p6m-dev.us.auth0.com".to_owned(),
                     client_id: "DkAzPi8iJITkDWKAoSjPON9jq6RSyCL9".to_owned(),
                     audience: "https://api-dev.p6m.dev/v1/".to_owned(),
@@ -272,6 +277,7 @@ impl P6mEnvironment {
             }
             false => Self {
                 config_dir: home_dir.join(".p6m"),
+                kube_dir: home_dir.join(".kube"),
                 domain: "auth.p6m.run".to_owned(),
                 client_id: "j4jEhWwe2od1eacxuocy0sfmbf7V4H8V".to_owned(),
                 audience: "https://api.p6m.run/v1/".to_owned(),
@@ -286,5 +292,9 @@ impl P6mEnvironment {
 
     pub fn config_dir(&self) -> &Utf8Path {
         self.config_dir.as_path()
+    }
+
+    pub fn kube_dir(&self) -> &Utf8Path {
+        self.kube_dir.as_path()
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -195,7 +195,14 @@ pub fn command() -> Command {
                     .long("org")
                     .required(false)
                     .action(clap::ArgAction::Set)
-                    .help("The JV Organization Name")
+                    .help("The JV Organization Name"),
+            )
+            .arg(
+                Arg::new("refresh")
+                    .long("refresh")
+                    .short('r')
+                    .action(clap::ArgAction::SetTrue)
+                    .help("Refresh access tokens")
             )
         )
         .subcommand(Command::new("whoami")

--- a/src/login.rs
+++ b/src/login.rs
@@ -1,5 +1,5 @@
 use crate::{auth::TokenRepository, cli::P6mEnvironment, whoami};
-use anyhow::Error;
+use anyhow::{Context, Error};
 use clap::ArgMatches;
 
 pub async fn execute(environment: P6mEnvironment, matches: &ArgMatches) -> Result<(), Error> {
@@ -7,13 +7,24 @@ pub async fn execute(environment: P6mEnvironment, matches: &ArgMatches) -> Resul
         .try_get_one::<String>("organization-name")
         .unwrap_or(None);
 
+    let refresh = matches.try_get_one::<bool>("refresh").unwrap_or(None);
+
     let mut token_repository = TokenRepository::new(&environment)?.force();
 
     if let Some(organization) = organization {
         token_repository.with_organization(organization)?;
     }
 
-    token_repository.try_login().await?;
+    match refresh {
+        Some(true) => token_repository
+            .try_refresh()
+            .await
+            .context("Please re-run `p6m login`")?,
+        _ => token_repository
+            .try_login()
+            .await
+            .context("Please re-run `p6m login`")?,
+    };
 
     println!("\nLogged in!\n");
     whoami::execute(environment, matches).await

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -2,4 +2,3 @@ pub mod artifact;
 pub mod aws;
 pub mod azure;
 pub mod git;
-pub mod openid;

--- a/src/sso/auth0.rs
+++ b/src/sso/auth0.rs
@@ -33,7 +33,7 @@ pub async fn configure_auth0(
     let email = token_repository
         .read_claims(AuthToken::Id)
         .context("unable to read claims")?
-        .context("missing claims")?
+        .context("missing claims on the ID Token")?
         .email
         .context("missing email")?;
 

--- a/src/sso/auth0.rs
+++ b/src/sso/auth0.rs
@@ -13,7 +13,7 @@ use crate::{
     cli::P6mEnvironment,
 };
 
-const BASE_URL: &str = "https://auth0.us-east-2.aws.prd.p6m.run/api";
+const BASE_URL: &str = "https://auth.p6m.dev/api";
 
 pub async fn configure_auth0(
     environment: &P6mEnvironment,
@@ -24,6 +24,11 @@ pub async fn configure_auth0(
     if let Some(organization) = organization {
         token_repository.with_organization(organization)?;
     }
+
+    token_repository
+        .try_refresh()
+        .await
+        .context("Please re-run `p6m login`")?;
 
     let id_token = token_repository
         .clone()

--- a/src/sso/auth0.rs
+++ b/src/sso/auth0.rs
@@ -1,0 +1,304 @@
+use std::{fs, path::PathBuf};
+
+use anyhow::{Context, Error};
+use kube::config::{
+    self, AuthInfo, Cluster, ExecConfig, Kubeconfig, NamedAuthInfo, NamedCluster, NamedContext,
+    Preferences,
+};
+use log::{debug, info, warn};
+
+use crate::{
+    auth::{AuthToken, TokenRepository},
+    auth0,
+    cli::P6mEnvironment,
+};
+
+const BASE_URL: &str = "https://auth0.us-east-2.aws.prd.p6m.run/api";
+
+pub async fn configure_auth0(
+    environment: &P6mEnvironment,
+    organization: Option<&String>,
+) -> Result<(), Error> {
+    let mut token_repository = TokenRepository::new(environment)?;
+
+    if let Some(organization) = organization {
+        token_repository.with_organization(organization)?;
+    }
+
+    let id_token = token_repository
+        .clone()
+        .read_token(AuthToken::Id)
+        .context("unable to read access token")?;
+
+    let client = auth0::Client::new()
+        .with_base_url(&BASE_URL.to_string())
+        .with_token(id_token);
+
+    let apps = client.apps().await.context("Unable to fetch apps")?;
+
+    let kube_apps = apps.contain_scope("login:kubernetes");
+
+    for app in kube_apps.clone() {
+        let name = app.name();
+        let url = app.url();
+        let org = match app.org() {
+            Some(org) => org,
+            _ => {
+                warn!(
+                    "Skipping: Kubernetes App {:?} is missing organization.",
+                    name
+                );
+                continue;
+            }
+        };
+        let certificate_authority_data = match app.certificate_authority() {
+            Ok(ca) => ca,
+            Err(_) => {
+                warn!(
+                    "Skipping: Kubernetes App {:?} is missing certificate authority.",
+                    name
+                );
+                continue;
+            }
+        };
+
+        debug!(
+            "found kube app: {:?}, url: {:?}, ca: {:?}",
+            name, url, certificate_authority_data
+        );
+
+        let kubeconfig = generate_kubeconfig(&name, &url, &org, &certificate_authority_data)
+            .await
+            .context("unable to generate kubeconfig")?;
+
+        match merge_kubeconfig(kubeconfig, &name).await {
+            Ok(update_res) => {
+                info!("auth0: update-kubectx: {}", update_res);
+            }
+            Err(err) => {
+                warn!("auth0: unable to update kubeconfig: {}", err);
+            }
+        };
+    }
+
+    Ok(())
+}
+
+async fn generate_kubeconfig(
+    name: &String,
+    url: &String,
+    org: &String,
+    ca_data: &String,
+) -> Result<Kubeconfig, Error> {
+    let mut kubeconfig = Kubeconfig::default();
+    kubeconfig.api_version = Some("v1".to_string());
+    kubeconfig.kind = Some("Config".to_string());
+    kubeconfig.preferences = Some(Preferences {
+        colors: None,
+        extensions: None,
+    });
+
+    kubeconfig.clusters = vec![NamedCluster {
+        name: url.clone(),
+        cluster: Some(Cluster {
+            server: Some(url.clone()),
+            certificate_authority_data: Some(ca_data.clone()),
+            ..Default::default()
+        }),
+    }];
+
+    kubeconfig.auth_infos = vec![NamedAuthInfo {
+        name: org.clone(),
+        auth_info: Some(AuthInfo {
+            exec: Some(ExecConfig {
+                api_version: Some("client.authentication.k8s.io/v1beta1".to_string()),
+                command: Some("p6m".into()),
+                args: Some(vec![
+                    "whoami".into(),
+                    "--org".into(),
+                    org.into(),
+                    "--output".into(),
+                    "k8s-auth".into(),
+                ]),
+                interactive_mode: None,
+                env: None,
+                drop_env: None,
+            }),
+            ..Default::default()
+        }),
+    }];
+
+    kubeconfig.contexts = vec![NamedContext {
+        name: name.clone(),
+        context: Some(config::Context {
+            cluster: url.clone(),
+            user: org.clone(),
+            ..Default::default()
+        }),
+    }];
+
+    // kubeconfig.current_context = Some(name.clone());
+
+    Ok(kubeconfig)
+}
+
+// pub async fn update_vcluster_kubecfgs(options: &KubeConfigOptions) -> Result<(), Error> {
+//     let config = create_config(options)
+//         .await
+//         .context("could not create kube config")?;
+
+//     let client = create_client(&config)
+//         .await
+//         .context("unable to create kube client")?;
+
+//     let secret_api: kube::Api<Secret> = kube::Api::all(client.clone());
+
+//     for secret in secret_api
+//         .list(&ListParams::default().labels(
+//             "p6m.dev/component=kubeconfig,meta.p6m.dev/controller=organization-controller-vcluster",
+//         ))
+//         .await?
+//     {
+//         match update_kubeconfig(&secret).await {
+//             Ok(update_res) => info!("vcluster: update-kubectx: {}", update_res),
+//             Err(err) => log::warn!("vcluster: unable to update kubeconfig: {}", err),
+//         }
+//     }
+
+//     Ok(())
+// }
+
+// async fn create_config(options: &KubeConfigOptions) -> Result<Config, Error> {
+//     match Config::from_kubeconfig(options).await {
+//         Ok(config) => Ok(config),
+//         Err(err) => {
+//             log::warn!("vcluster: unable to create config: {}", err);
+//             Err(anyhow::anyhow!(err))
+//         }
+//     }
+// }
+
+// async fn create_client(config: &Config) -> Result<Client, Error> {
+//     kube::Client::try_from(config.clone()).context("could not create client")
+// }
+
+// async fn update_kubeconfig(secret: &Secret) -> Result<String, Error> {
+//     let path = dirs::home_dir()
+//         .map(|path| path.join(".kube").join("config"))
+//         .unwrap_or_else(|| PathBuf::from(".kube").join("config"));
+
+//     let kubeconfig = Kubeconfig::read_from(path.as_path()).unwrap_or(Kubeconfig::default());
+
+//     let config = String::from_utf8(
+//         secret
+//             .data
+//             .as_ref()
+//             .unwrap_or(&BTreeMap::new())
+//             .get("config")
+//             .context("missing config on secret")?
+//             .clone()
+//             .0
+//             .clone(),
+//     )
+//     .context("unable to convert config to string")?;
+
+//     let mut new_kubeconfig =
+//         Kubeconfig::from_yaml(&config).context("couldn't create kube config from secret config")?;
+
+//     let server_name =
+//         uniqueify_kubeconfig(&mut new_kubeconfig).context("couldn't uniqueify kubeconfig")?;
+
+//     let kubeconfig = kubeconfig
+//         .merge(new_kubeconfig)
+//         .context("unable to merge configs")?;
+
+//     save_kubeconfig(&kubeconfig, path.as_path())
+//         .await
+//         .context("unable to save kube config")?;
+
+//     Ok(format!(
+//         "Updated context {} in {}",
+//         server_name,
+//         path.to_string_lossy(),
+//     )
+//     .to_string())
+// }
+
+// fn uniqueify_kubeconfig(kubeconfig: &mut Kubeconfig) -> Result<String, Error> {
+//     let current_context = kubeconfig
+//         .current_context
+//         .clone()
+//         .context("missing current context")?;
+
+//     let context = kubeconfig
+//         .contexts
+//         .iter_mut()
+//         .find(|c| c.name == current_context)
+//         .context("unable to find current named context")?;
+
+//     let cluster = kubeconfig
+//         .clusters
+//         .iter_mut()
+//         .find(|c| {
+//             Some(c.name.clone())
+//                 == context
+//                     .context
+//                     .as_ref()
+//                     .context("missing context")
+//                     .ok()
+//                     .map(|c| c.cluster.clone())
+//         })
+//         .context("unable to find current named cluster")?;
+
+//     let auth_info = kubeconfig
+//         .auth_infos
+//         .iter_mut()
+//         .find(|a| {
+//             Some(a.name.clone())
+//                 == context
+//                     .context
+//                     .as_ref()
+//                     .context("missing context")
+//                     .ok()
+//                     .map(|c| c.user.clone())
+//         })
+//         .context("unable to find current named auth info")?;
+
+//     let server_name = cluster
+//         .cluster
+//         .as_ref()
+//         .and_then(|c| c.server.clone())
+//         .context("missing server name")?
+//         .replace("https://", "");
+
+//     // Change every identifier to be server_name for uniqueness
+//     context.name = server_name.clone();
+//     cluster.name = server_name.clone();
+//     auth_info.name = server_name.clone();
+
+//     context.context.as_mut().map(|c| {
+//         c.cluster = cluster.name.clone();
+//         c.user = auth_info.name.clone();
+//     });
+
+//     Ok(server_name)
+// }
+
+async fn merge_kubeconfig(kubeconfig: Kubeconfig, name: &String) -> Result<String, Error> {
+    let path = dirs::home_dir()
+        .map(|path| path.join(".kube").join("config"))
+        .unwrap_or_else(|| PathBuf::from(".kube").join("config"));
+
+    let existing = Kubeconfig::read_from(path.clone().as_path()).unwrap_or(Kubeconfig::default());
+
+    let kubeconfig = kubeconfig
+        .merge(existing)
+        .context("unable to merge configs")?;
+
+    let yaml =
+        serde_yaml::to_string(&kubeconfig).context("unable to convert kubeconfig to yaml")?;
+
+    fs::write(path.clone(), yaml).context("unable to write kubeconfig")?;
+
+    Ok(format!("Updated context {} in {}", name, path.to_string_lossy(),).to_string())
+}

--- a/src/sso/auth0.rs
+++ b/src/sso/auth0.rs
@@ -30,6 +30,13 @@ pub async fn configure_auth0(
         .read_token(AuthToken::Id)
         .context("unable to read access token")?;
 
+    let email = token_repository
+        .read_claims(AuthToken::Id)
+        .context("unable to read claims")?
+        .context("missing claims")?
+        .email
+        .context("missing email")?;
+
     let client = auth0::Client::new()
         .with_base_url(&BASE_URL.to_string())
         .with_token(id_token);
@@ -51,6 +58,7 @@ pub async fn configure_auth0(
                 continue;
             }
         };
+        let user_name = format!("{} ({})", email, org);
         let certificate_authority_data = match app.certificate_authority() {
             Ok(ca) => ca,
             Err(_) => {
@@ -67,9 +75,10 @@ pub async fn configure_auth0(
             name, url, certificate_authority_data
         );
 
-        let kubeconfig = generate_kubeconfig(&name, &url, &org, &certificate_authority_data)
-            .await
-            .context("unable to generate kubeconfig")?;
+        let kubeconfig =
+            generate_kubeconfig(&name, &user_name, &url, &org, &certificate_authority_data)
+                .await
+                .context("unable to generate kubeconfig")?;
 
         match merge_kubeconfig(kubeconfig, &name).await {
             Ok(update_res) => {
@@ -85,7 +94,8 @@ pub async fn configure_auth0(
 }
 
 async fn generate_kubeconfig(
-    name: &String,
+    cluster_name: &String,
+    user_name: &String,
     url: &String,
     org: &String,
     ca_data: &String,
@@ -108,7 +118,7 @@ async fn generate_kubeconfig(
     }];
 
     kubeconfig.auth_infos = vec![NamedAuthInfo {
-        name: org.clone(),
+        name: user_name.clone(),
         auth_info: Some(AuthInfo {
             exec: Some(ExecConfig {
                 api_version: Some("client.authentication.k8s.io/v1beta1".to_string()),
@@ -129,10 +139,10 @@ async fn generate_kubeconfig(
     }];
 
     kubeconfig.contexts = vec![NamedContext {
-        name: name.clone(),
+        name: cluster_name.clone(),
         context: Some(config::Context {
             cluster: url.clone(),
-            user: org.clone(),
+            user: user_name.clone(),
             ..Default::default()
         }),
     }];
@@ -141,148 +151,6 @@ async fn generate_kubeconfig(
 
     Ok(kubeconfig)
 }
-
-// pub async fn update_vcluster_kubecfgs(options: &KubeConfigOptions) -> Result<(), Error> {
-//     let config = create_config(options)
-//         .await
-//         .context("could not create kube config")?;
-
-//     let client = create_client(&config)
-//         .await
-//         .context("unable to create kube client")?;
-
-//     let secret_api: kube::Api<Secret> = kube::Api::all(client.clone());
-
-//     for secret in secret_api
-//         .list(&ListParams::default().labels(
-//             "p6m.dev/component=kubeconfig,meta.p6m.dev/controller=organization-controller-vcluster",
-//         ))
-//         .await?
-//     {
-//         match update_kubeconfig(&secret).await {
-//             Ok(update_res) => info!("vcluster: update-kubectx: {}", update_res),
-//             Err(err) => log::warn!("vcluster: unable to update kubeconfig: {}", err),
-//         }
-//     }
-
-//     Ok(())
-// }
-
-// async fn create_config(options: &KubeConfigOptions) -> Result<Config, Error> {
-//     match Config::from_kubeconfig(options).await {
-//         Ok(config) => Ok(config),
-//         Err(err) => {
-//             log::warn!("vcluster: unable to create config: {}", err);
-//             Err(anyhow::anyhow!(err))
-//         }
-//     }
-// }
-
-// async fn create_client(config: &Config) -> Result<Client, Error> {
-//     kube::Client::try_from(config.clone()).context("could not create client")
-// }
-
-// async fn update_kubeconfig(secret: &Secret) -> Result<String, Error> {
-//     let path = dirs::home_dir()
-//         .map(|path| path.join(".kube").join("config"))
-//         .unwrap_or_else(|| PathBuf::from(".kube").join("config"));
-
-//     let kubeconfig = Kubeconfig::read_from(path.as_path()).unwrap_or(Kubeconfig::default());
-
-//     let config = String::from_utf8(
-//         secret
-//             .data
-//             .as_ref()
-//             .unwrap_or(&BTreeMap::new())
-//             .get("config")
-//             .context("missing config on secret")?
-//             .clone()
-//             .0
-//             .clone(),
-//     )
-//     .context("unable to convert config to string")?;
-
-//     let mut new_kubeconfig =
-//         Kubeconfig::from_yaml(&config).context("couldn't create kube config from secret config")?;
-
-//     let server_name =
-//         uniqueify_kubeconfig(&mut new_kubeconfig).context("couldn't uniqueify kubeconfig")?;
-
-//     let kubeconfig = kubeconfig
-//         .merge(new_kubeconfig)
-//         .context("unable to merge configs")?;
-
-//     save_kubeconfig(&kubeconfig, path.as_path())
-//         .await
-//         .context("unable to save kube config")?;
-
-//     Ok(format!(
-//         "Updated context {} in {}",
-//         server_name,
-//         path.to_string_lossy(),
-//     )
-//     .to_string())
-// }
-
-// fn uniqueify_kubeconfig(kubeconfig: &mut Kubeconfig) -> Result<String, Error> {
-//     let current_context = kubeconfig
-//         .current_context
-//         .clone()
-//         .context("missing current context")?;
-
-//     let context = kubeconfig
-//         .contexts
-//         .iter_mut()
-//         .find(|c| c.name == current_context)
-//         .context("unable to find current named context")?;
-
-//     let cluster = kubeconfig
-//         .clusters
-//         .iter_mut()
-//         .find(|c| {
-//             Some(c.name.clone())
-//                 == context
-//                     .context
-//                     .as_ref()
-//                     .context("missing context")
-//                     .ok()
-//                     .map(|c| c.cluster.clone())
-//         })
-//         .context("unable to find current named cluster")?;
-
-//     let auth_info = kubeconfig
-//         .auth_infos
-//         .iter_mut()
-//         .find(|a| {
-//             Some(a.name.clone())
-//                 == context
-//                     .context
-//                     .as_ref()
-//                     .context("missing context")
-//                     .ok()
-//                     .map(|c| c.user.clone())
-//         })
-//         .context("unable to find current named auth info")?;
-
-//     let server_name = cluster
-//         .cluster
-//         .as_ref()
-//         .and_then(|c| c.server.clone())
-//         .context("missing server name")?
-//         .replace("https://", "");
-
-//     // Change every identifier to be server_name for uniqueness
-//     context.name = server_name.clone();
-//     cluster.name = server_name.clone();
-//     auth_info.name = server_name.clone();
-
-//     context.context.as_mut().map(|c| {
-//         c.cluster = cluster.name.clone();
-//         c.user = auth_info.name.clone();
-//     });
-
-//     Ok(server_name)
-// }
 
 async fn merge_kubeconfig(kubeconfig: Kubeconfig, name: &String) -> Result<String, Error> {
     let path = dirs::home_dir()

--- a/src/sso/mod.rs
+++ b/src/sso/mod.rs
@@ -1,27 +1,42 @@
+pub mod auth0;
 pub mod aws;
 pub mod azure;
 pub mod vcluster;
 
+use std::fs::create_dir_all;
+
 use anyhow::Error;
+use auth0::configure_auth0;
 use aws::configure_aws;
 use azure::configure_azure;
 use clap::ArgMatches;
 
-pub async fn execute(matches: &ArgMatches) -> Result<(), Error> {
+use crate::cli::P6mEnvironment;
+
+pub async fn execute(environment: P6mEnvironment, matches: &ArgMatches) -> Result<(), Error> {
+    create_dir_all(environment.kube_dir())?;
+
+    let organization = matches
+        .try_get_one::<String>("organization-name")
+        .unwrap_or(None);
+
     match matches.subcommand() {
+        Some(("auth0", _)) => configure_auth0(&environment, organization).await,
         Some(("aws", _)) => configure_aws().await,
         Some(("azure", _)) => configure_azure().await,
         Some((command, _)) => Err(Error::msg(format!(
             "Unimplemented sso command: '{}'",
             command
         ))),
-        None => configure_sso().await,
+        None => configure_sso(&environment).await,
     }?;
 
     Ok(())
 }
 
-async fn configure_sso() -> Result<(), Error> {
+async fn configure_sso(_environment: &P6mEnvironment) -> Result<(), Error> {
+    // TODO: enable auth0
+    // configure_auth0(environment).await?;
     configure_aws().await?;
     configure_azure().await?;
     Ok(())

--- a/src/sso/mod.rs
+++ b/src/sso/mod.rs
@@ -23,7 +23,7 @@ pub async fn execute(environment: P6mEnvironment, matches: &ArgMatches) -> Resul
     match matches.subcommand() {
         Some(("auth0", _)) => configure_auth0(&environment, organization)
             .await
-            .context("Unable to SSO using Auth0. Please run `p6m login`."),
+            .context("Unable to SSO using Auth0"),
         Some(("aws", _)) => configure_aws().await,
         Some(("azure", _)) => configure_azure().await,
         Some((command, _)) => Err(Error::msg(format!(

--- a/src/sso/mod.rs
+++ b/src/sso/mod.rs
@@ -5,7 +5,7 @@ pub mod vcluster;
 
 use std::fs::create_dir_all;
 
-use anyhow::Error;
+use anyhow::{Context, Error};
 use auth0::configure_auth0;
 use aws::configure_aws;
 use azure::configure_azure;
@@ -21,7 +21,9 @@ pub async fn execute(environment: P6mEnvironment, matches: &ArgMatches) -> Resul
         .unwrap_or(None);
 
     match matches.subcommand() {
-        Some(("auth0", _)) => configure_auth0(&environment, organization).await,
+        Some(("auth0", _)) => configure_auth0(&environment, organization)
+            .await
+            .context("Unable to SSO using Auth0. Please run `p6m login`."),
         Some(("aws", _)) => configure_aws().await,
         Some(("azure", _)) => configure_azure().await,
         Some((command, _)) => Err(Error::msg(format!(

--- a/src/whoami.rs
+++ b/src/whoami.rs
@@ -1,15 +1,15 @@
 use crate::auth::{AuthToken, TokenRepository};
 use crate::cli::P6mEnvironment;
-use crate::models::openid::DeviceCodeRequest;
 use anyhow::{Context, Error};
 use clap::ArgMatches;
-use log::debug;
 
 #[derive(clap::ValueEnum, Clone, Debug, PartialEq)]
 pub enum Output {
     Default,
     Json,
     K8sAuth,
+    AccessToken,
+    IdToken,
 }
 
 pub async fn execute(environment: P6mEnvironment, matches: &ArgMatches) -> Result<(), Error> {
@@ -17,45 +17,18 @@ pub async fn execute(environment: P6mEnvironment, matches: &ArgMatches) -> Resul
         .try_get_one("output")
         .unwrap_or(Some(&Output::Default));
 
-    let mut device_code_request = DeviceCodeRequest::new(&environment)
-        .await?
-        .interactive(false);
+    let organization = matches
+        .try_get_one::<String>("organization-name")
+        .unwrap_or(None);
 
-    let organization = matches.get_one::<String>("organization-name");
+    let mut token_repository = TokenRepository::new(&environment)?;
 
-    let mut token_repository = device_code_request
-        .exchange_for_token()
-        .await
-        .context("You are not logged in. First run `p6m login` to log in.")?;
-
-    if let Some(organization) = organization.clone() {
-        device_code_request = device_code_request
-            .with_organization(organization)
-            .await
-            .context("You are not logged in. First run `p6m login` (without --org) to log in.")?
-            .with_scope("login:kubernetes");
-
-        token_repository = match device_code_request.exchange_for_token().await {
-            Ok(token_repoository) => token_repoository,
-            Err(err) => {
-                debug!(
-                    "Unable to passively get token. Turning on interactive+force: {}",
-                    err
-                );
-                // Switch on force new
-                // And allow interactivity
-                device_code_request
-                    .clone()
-                    .interactive(true)
-                    .force_new()
-                    .with_scope("login:kubernetes")
-                    .exchange_for_token()
-                    .await?
-            }
-        };
+    if let Some(organization) = organization {
+        token_repository.with_organization(organization)?;
+        token_repository.with_scope("login:kubernetes");
     }
 
-    let user_info = token_repository.user_info().await?;
+    token_repository.try_login().await?;
 
     println!(
         "{}",
@@ -66,8 +39,18 @@ pub async fn execute(environment: P6mEnvironment, matches: &ArgMatches) -> Resul
                     organization.context("--org is a required for --output k8s-auth")?,
                 )
                 .await?,
-            Some(Output::Json) => user_info.to_json()?,
-            None | Some(Output::Default) => user_info.to_string(),
+            Some(Output::Json) => token_repository.to_json()?,
+            Some(Output::IdToken) => token_repository
+                .clone()
+                .read_token(AuthToken::Id)
+                .context("unable to read id token")?
+                .context("missing id token")?,
+            Some(Output::AccessToken) => token_repository
+                .clone()
+                .read_token(AuthToken::Access)
+                .context("unable to read id token")?
+                .context("missing id token")?,
+            None | Some(Output::Default) => token_repository.to_string(),
         }
     );
 
@@ -82,9 +65,7 @@ async fn k8s_auth(
     Ok(serde_json::json!({
         "kind": "ExecCredential",
         "apiVersion": "client.authentication.k8s.io/v1beta1",
-        "spec": {
-            "interactive": false
-        },
+        "spec": {},
         "status": {
             "expirationTimestamp": token_repository.clone().read_expiration(AuthToken::Id)?,
             "token": token_repository.clone().read_token(AuthToken::Id)?,

--- a/src/whoami.rs
+++ b/src/whoami.rs
@@ -91,7 +91,9 @@ async fn k8s_auth(
     Ok(serde_json::json!({
         "kind": "ExecCredential",
         "apiVersion": "client.authentication.k8s.io/v1beta1",
-        "spec": {},
+        "spec": {
+            "interactive": true,
+        },
         "status": {
             "expirationTimestamp": token_repository.clone().read_expiration(AuthToken::Id)?,
             "token": token_repository.clone().read_token(AuthToken::Id)?,


### PR DESCRIPTION
## Adding `p6m sso auth0` command

This PR introduces the beta feature of `p6m sso auth0`.
- Right now the only way to invoke this is by explicitly running `p6m sso auth0`. 
- The "legacy" behavior of `p6m sso` still does the same old `aws`/`azure` loopy loops.

The workflow is as follows:
 - New user runs `p6m sso auth0` --> User told to do `p6m login`
 - User re-runs `p6m sso auth0` --> Auth0 API queried for Apps
 - `~/.kube/config` updated
 - User runs `k9s` or `kubectl get namespaces`
 - `kubectl` runs `p6m whoami --org {the-org-name} --output k8s-auth` behind the scenes
 - Browser opens for Org Scoped token
 - Org scoped token created, `k9s` or `kubectl` commands work
 - Tokens refresh after 12 hours
 
I had to completely rewire how `DeviceCodeRequest` workew and make `TokenRepository` the entry point for tokens for the `p6m whoami` and `p6m login` commands. This was because I needed users to first do a naked `p6m login` command before a `p6m login --org ...` command, since the Org Name <-> Org ID map comes from the base access token.

### Upcoming work:
 - Have some people kick the tires on `p6m sso auth0`
 - Uncomment `configure_auth0()` from the `configure_sso()` function, which will bring `p6m sso auth0` out of "beta"
 - Place `configure_aws()` behind a  `--legacy` `ArgMatches`
 - Make auth0 play nicely with azure then place `configure_azure()` behind a `--legacy` `ArgMatches`