### PR TITLE
fix/kubectx-names

### DIFF
--- a/src/auth0/types.rs
+++ b/src/auth0/types.rs
@@ -40,7 +40,7 @@ pub struct App {
 }
 
 impl App {
-    pub fn readable_name(&self) -> String {
+    pub fn display_name(&self) -> String {
         self.name.clone()
     }
 
@@ -48,7 +48,7 @@ impl App {
         self.metadata
             .get("ClaimName")
             .map(|s| s.to_string())
-            .unwrap_or(self.readable_name())
+            .unwrap_or(self.display_name())
             .chars()
             .map(|c| if c.is_alphanumeric() { c } else { '-' })
             .collect()

--- a/src/auth0/types.rs
+++ b/src/auth0/types.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use urlencoding::decode;
@@ -34,11 +36,20 @@ pub struct App {
     pub url: String,
     pub origins: Vec<String>,
     pub scopes: Vec<String>,
+    pub metadata: BTreeMap<String, String>,
 }
 
 impl App {
-    pub fn name(&self) -> String {
+    pub fn readable_name(&self) -> String {
         self.name.clone()
+    }
+
+    pub fn machine_name(&self) -> String {
+        self.metadata
+            .get("ClaimName")
+            .map(|s| s.to_string())
+            .unwrap_or(self.readable_name())
+            .replace(" ", "-")
     }
 
     pub fn url(&self) -> String {

--- a/src/auth0/types.rs
+++ b/src/auth0/types.rs
@@ -49,7 +49,9 @@ impl App {
             .get("ClaimName")
             .map(|s| s.to_string())
             .unwrap_or(self.readable_name())
-            .replace(" ", "-")
+            .chars()
+            .map(|c| if c.is_alphanumeric() { c } else { '-' })
+            .collect()
     }
 
     pub fn url(&self) -> String {

--- a/src/sso/auth0.rs
+++ b/src/sso/auth0.rs
@@ -51,7 +51,7 @@ pub async fn configure_auth0(
     let kube_apps = apps.contain_scope("login:kubernetes");
 
     for app in kube_apps.clone() {
-        let name = app.name();
+        let name = app.machine_name();
         let url = app.url();
         let org = match app.org() {
             Some(org) => org,
@@ -152,7 +152,7 @@ async fn generate_kubeconfig(
         }),
     }];
 
-    // kubeconfig.current_context = Some(name.clone());
+    kubeconfig.current_context = Some(cluster_name.clone());
 
     Ok(kubeconfig)
 }

--- a/src/sso/auth0.rs
+++ b/src/sso/auth0.rs
@@ -51,7 +51,7 @@ pub async fn configure_auth0(
     let kube_apps = apps.contain_scope("login:kubernetes");
 
     for app in kube_apps.clone() {
-        let name = app.machine_name();
+        let name = app.machine_name().replace("-auth0", "");
         let url = app.url();
         let org = match app.org() {
             Some(org) => org,


### PR DESCRIPTION
Bugfixes:
 - Uses `metadata.ClaimName` as the name for `kubectx`
 - Sets `currentContext` to avoid thrashy-ness after first run