### PR TITLE
ws check: show select prompt by default

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -23,13 +23,13 @@ fn generate_git_constants() -> std::io::Result<()> {
     };
 
     let is_dirty_output = Command::new("git")
-        .args(&["status", "--porcelain"])
+        .args(["status", "--porcelain"])
         .output()
         .expect("Failed to execute git status");
     let is_dirty = !is_dirty_output.stdout.is_empty();
 
     let commit_hash_output = Command::new("git")
-        .args(&["rev-parse", "HEAD"])
+        .args(["rev-parse", "HEAD"])
         .output()
         .expect("Failed to execute command");
     let commit_hash = from_utf8(&commit_hash_output.stdout).expect("Invalid UTF-8");

--- a/src/workstation/check/common.rs
+++ b/src/workstation/check/common.rs
@@ -16,7 +16,7 @@ pub fn print_see_also(path: &str) {
 
 pub fn print_success_lines(lines: Lines<&[u8]>, all_lines: bool) {
     lines
-        .filter_map(|line| line.ok())
+        .map_while(Result::ok)
         .enumerate()
         .for_each(|(index, line)| {
             if index == 0 || all_lines {

--- a/src/workstation/check/mod.rs
+++ b/src/workstation/check/mod.rs
@@ -1,5 +1,4 @@
 use clap::{ArgMatches, ValueEnum};
-use strum::IntoEnumIterator;
 
 mod check_archetect;
 mod check_artifact_management;
@@ -10,8 +9,8 @@ mod check_javascript;
 mod check_kubernetes;
 mod check_python;
 mod check_scm;
-mod common;
 mod check_self;
+mod common;
 
 pub use common::Ecosystem;
 
@@ -21,21 +20,26 @@ pub async fn execute(args: &ArgMatches) -> anyhow::Result<()> {
             check_ecosystem(ecosystem, args).await?;
         }
     } else {
-        for ecosystem in Ecosystem::iter() {
-            check_ecosystem(&ecosystem, args).await?;
-        }
+        execute_interactive(args).await?;
+        // for ecosystem in Ecosystem::iter() {
+        //     check_ecosystem(&ecosystem, args).await?;
+        // }
     }
 
     Ok(())
 }
 
 pub async fn execute_interactive(args: &ArgMatches) -> anyhow::Result<()> {
-    let ecosystems = Ecosystem::value_variants().iter().map(|ecosystem| ecosystem.to_string())
+    let ecosystems = Ecosystem::value_variants()
+        .iter()
+        .map(|ecosystem| ecosystem.to_string())
         .collect::<Vec<String>>();
-    let prompt = inquire::MultiSelect::new("Ecosystems:", ecosystems);
+    let prompt = inquire::MultiSelect::new("Ecosystems:", ecosystems).with_default(&[0, 1]);
     match prompt.prompt_skippable() {
         Ok(Some(ecosystems)) => {
-            let ecosystems = ecosystems.iter().map(|ecosystem| Ecosystem::from_str(ecosystem, true).expect("Cannot fail"))
+            let ecosystems = ecosystems
+                .iter()
+                .map(|ecosystem| Ecosystem::from_str(ecosystem, true).expect("Cannot fail"))
                 .collect::<Vec<Ecosystem>>();
             for ecosystem in ecosystems {
                 check_ecosystem(&ecosystem, args).await?
@@ -46,7 +50,6 @@ pub async fn execute_interactive(args: &ArgMatches) -> anyhow::Result<()> {
     }
 
     Ok(())
-
 }
 
 async fn check_ecosystem(ecosystem: &Ecosystem, args: &ArgMatches) -> anyhow::Result<()> {


### PR DESCRIPTION
When no ecosystems are specified, show a select prompt with common defaults selected.

This is an effort to make the tool more intuitive and useful, even if users have forgotten exact use.