### PR TITLE
[sso] Default to `p6m sso auth0` by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,7 +2432,7 @@ checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
 
 [[package]]
 name = "p6m"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "p6m"
 publish = ["p6m"]
 readme = "README.md"
 repository = "https://github.com/p6m-run/p6m-cli"
-version = "0.6.3"
+version = "0.7.0"
 
 [workspace]
 members = ["."]

--- a/src/sso/auth0.rs
+++ b/src/sso/auth0.rs
@@ -66,7 +66,7 @@ pub async fn configure_auth0(
 }
 
 async fn generate_kubeconfig(app: &App, email: &String) -> Result<(Kubeconfig, String), Error> {
-    let cluster_name = format!("p6m-{}", app.machine_name().replace("-auth0", ""));
+    let cluster_name = format!("{}.p6m", app.machine_name().replace("-auth0", ""));
     let url = app.url();
     let org = app.org().context("missing org")?;
     let ca = app.ca().context("Missing certificate authority")?;

--- a/src/sso/mod.rs
+++ b/src/sso/mod.rs
@@ -30,16 +30,18 @@ pub async fn execute(environment: P6mEnvironment, matches: &ArgMatches) -> Resul
             "Unimplemented sso command: '{}'",
             command
         ))),
-        None => configure_sso(&environment).await,
+        None => configure_sso(&environment, organization).await,
     }?;
 
     Ok(())
 }
 
-async fn configure_sso(_environment: &P6mEnvironment) -> Result<(), Error> {
-    // TODO: enable auth0
-    // configure_auth0(environment).await?;
-    configure_aws().await?;
-    configure_azure().await?;
+async fn configure_sso(
+    environment: &P6mEnvironment,
+    organization: Option<&String>,
+) -> Result<(), Error> {
+    configure_auth0(environment, organization).await?;
+    // configure_aws().await?;
+    // configure_azure().await?;
     Ok(())
 }


### PR DESCRIPTION
## Setting the `p6m sso` command to do **ONLY** auth with auth0 by default

### Behavior

 - Running `p6m sso` is an alias for `p6m sso auth0`
 - Running `p6m sso` will **NO LONGER** run `p6m sso aws` and `p6m sso azure`
   - Running `p6m sso aws` will work as it used to, just **not happen automatically** via `p6m sso`
   - Running `p6m sso azure` will work as it used to, just **not happen automatically** via `p6m sso`
 - Bumped to `0.7.0` since this is a functional change, but has backwards compatiblity
   
### Cosmetic changes

 - The name of the cluster in `~./kube/config` is changing from:
    - `p6m-ybor-playground-dev-us-east-2`
    - to `ybor-playground-dev-us-east-2.p6m`
 - Motivation: cosmetic to make `p6m` less prominent in the cluster name