### PR TITLE
request "roles" claim on JWTs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,6 +131,11 @@ jobs:
           echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_ENV 
           vcpkg install openssl:x64-windows-static-md
 
+      - name: Run Tests
+        shell: bash
+        run: |
+          cargo test -- --show-output
+
       - name: Build Binary
         shell: bash
         run: |

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -43,5 +43,7 @@ jobs:
         if: runner.os == 'Windows'
       - run: vcpkg install openssl:x64-windows-static-md
         if: runner.os == 'Windows'
+      - name: Test it!
+        run: cargo test -- --show-output
       - name: Build it!
         run: cargo build --release

--- a/src/login.rs
+++ b/src/login.rs
@@ -15,16 +15,18 @@ pub async fn execute(environment: P6mEnvironment, matches: &ArgMatches) -> Resul
 
     let mut token_repository = TokenRepository::new(&environment.auth_n, &environment.auth_dir)?;
 
-    token_repository.force().with_scope(
-        "roles",
-        Claims {
-            roles: Some(vec!["*".into()]), // ["*"] is a special case to allow any
-            ..Default::default()
-        },
-    );
+    token_repository.force();
 
     if let Some(organization) = organization {
-        token_repository.with_organization(organization)?;
+        token_repository
+            .with_organization(organization)?
+            .with_scope(
+                "roles",
+                Claims {
+                    roles: Some(vec!["*".into()]), // ["*"] is a special case to allow any
+                    ..Default::default()
+                },
+            );
     }
 
     match refresh {

--- a/src/login.rs
+++ b/src/login.rs
@@ -13,8 +13,8 @@ pub async fn execute(environment: P6mEnvironment, matches: &ArgMatches) -> Resul
 
     let refresh = matches.try_get_one::<bool>("refresh").unwrap_or(None);
 
-    let mut token_repository =
-        TokenRepository::new(&environment.auth_n, &environment.auth_dir)?.force();
+    let mut token_repository = TokenRepository::new(&environment.auth_n, &environment.auth_dir)?;
+    token_repository.force();
 
     if let Some(organization) = organization {
         token_repository.with_organization(organization)?;

--- a/src/login.rs
+++ b/src/login.rs
@@ -1,5 +1,5 @@
 use crate::{
-    auth::{TokenRepository, TryReason},
+    auth::{Claims, TokenRepository, TryReason},
     cli::P6mEnvironment,
     whoami,
 };
@@ -14,7 +14,14 @@ pub async fn execute(environment: P6mEnvironment, matches: &ArgMatches) -> Resul
     let refresh = matches.try_get_one::<bool>("refresh").unwrap_or(None);
 
     let mut token_repository = TokenRepository::new(&environment.auth_n, &environment.auth_dir)?;
-    token_repository.force();
+
+    token_repository.force().with_scope(
+        "roles",
+        Claims {
+            roles: Some(vec!["*".into()]), // ["*"] is a special case to allow any
+            ..Default::default()
+        },
+    );
 
     if let Some(organization) = organization {
         token_repository.with_organization(organization)?;

--- a/src/whoami.rs
+++ b/src/whoami.rs
@@ -72,14 +72,6 @@ pub async fn execute(environment: P6mEnvironment, matches: &ArgMatches) -> Resul
 
     let mut token_repository = TokenRepository::new(&environment.auth_n, &environment.auth_dir)?;
 
-    token_repository.with_scope(
-        "roles",
-        Claims {
-            roles: Some(vec!["*".into()]), // ["*"] is a special case to allow any
-            ..Default::default()
-        },
-    );
-
     if let Some(organization) = organization {
         if output == Some(&Output::K8sAuth) {
             token_repository.with_scope(
@@ -93,7 +85,14 @@ pub async fn execute(environment: P6mEnvironment, matches: &ArgMatches) -> Resul
 
         token_repository
             .with_organization(organization)
-            .context("Unknown organizatization")?;
+            .context("Unknown organizatization")?
+            .with_scope(
+                "roles",
+                Claims {
+                    roles: Some(vec!["*".into()]), // ["*"] is a special case to allow any
+                    ..Default::default()
+                },
+            );
     }
 
     match token_repository


### PR DESCRIPTION
## Request the `roles` claim

The `auth.p6m.dev` API recently only included roles unless explicitly requested. [[source](https://github.com/p6m-dev/auth.p6m.dev/commit/bb58880b56dffd3e910a694330aee48841463a0b)]

This had the side effect of breaking `p6m sso` functionality with AWS clusters, which are tied directly into Auth0 and do Role Assertion in `kube-apiserver`. [[source](https://github.com/p6m-run/platform-cluster-operator/blob/main/crates/platform_cluster_operator_model/src/platform_cluster.rs#L928)]

This will update all `whoami` and `login` commands to request tokens containing the `roles` scope, and assert that `https://p6m.dev/v1/roles` is on the ID token.

### Bonus

 - Added tests for it and have the GitHub Action run `cargo test` now.