### PR TITLE
add urn:auth:dev:true when "dev" mode is enabled

### DIFF
--- a/src/auth/token_repository.rs
+++ b/src/auth/token_repository.rs
@@ -324,7 +324,7 @@ impl TokenRepository {
     }
 
     pub async fn with_authn_app_id(&mut self, id: &String) -> Result<&mut Self> {
-        let app = Client::new()
+        let app = Client::new(&self.auth_n.apps_uri())
             .with_token(self.read_token(AuthToken::Id)?)
             .app(id)
             .await
@@ -703,6 +703,8 @@ impl TokenRepository {
         for scope in self.scope_str().await?.split(" ") {
             acr_values.push(format!("urn:auth:acr:scope:{}", scope));
         }
+
+        acr_values.extend(self.auth_n.acr_values.clone().unwrap_or_default());
 
         if acr_values.len() > 0 {
             form.push(("acr_values".into(), acr_values.join(" ")));

--- a/src/auth/token_repository.rs
+++ b/src/auth/token_repository.rs
@@ -260,7 +260,7 @@ impl TokenRepository {
             auth_dir: auth_dir.clone(),
             organization_id: None,
             force: false,
-            scopes: vec![],
+            scopes: auth_n.scopes.clone().unwrap_or_default(),
             default_scopes: Self::DEFAULT_SCOPES.to_string(),
             desired_claims: Claims::default(),
         };
@@ -703,8 +703,6 @@ impl TokenRepository {
         for scope in self.scope_str().await?.split(" ") {
             acr_values.push(format!("urn:auth:acr:scope:{}", scope));
         }
-
-        acr_values.extend(self.auth_n.acr_values.clone().unwrap_or_default());
 
         if acr_values.len() > 0 {
             form.push(("acr_values".into(), acr_values.join(" ")));

--- a/src/auth0/api.rs
+++ b/src/auth0/api.rs
@@ -4,9 +4,6 @@ use url::Url;
 
 use super::{types::Apps, App};
 
-const BASE_URL: &str = "https://auth.p6m.dev/api";
-// const BASE_URL: &str = "https://9b6hcz5ny6.execute-api.us-east-2.amazonaws.com/api";
-
 #[derive(Debug, Clone)]
 pub struct Client {
     base_url: Option<String>,
@@ -15,9 +12,9 @@ pub struct Client {
 }
 
 impl Client {
-    pub fn new() -> Self {
+    pub fn new(base_url: &Option<String>) -> Self {
         Self {
-            base_url: Some(BASE_URL.to_string()),
+            base_url: base_url.clone(),
             token: None,
             client: reqwest::Client::builder()
                 .user_agent(format!("p6m-cli/{}", env!("CARGO_PKG_VERSION")))

--- a/src/auth0/types.rs
+++ b/src/auth0/types.rs
@@ -85,6 +85,9 @@ impl AuthN {
             "grant_type".to_string(),
             "urn:ietf:params:oauth:grant-type:device_code".to_string(),
         );
+        if let Some(acr_values) = self.acr_values.clone() {
+            form.insert("acr_values".to_string(), acr_values.join(" "));
+        }
         trace!("device_code_form_data: {:?}", form);
         Ok(form)
     }

--- a/src/auth0/types.rs
+++ b/src/auth0/types.rs
@@ -48,8 +48,8 @@ pub struct AuthN {
     pub discovery_uri: Option<String>,
     pub token_preference: Option<AuthToken>,
     pub params: Option<BTreeMap<String, String>>,
-    pub acr_values: Option<Vec<String>>,
     pub apps_uri: Option<String>,
+    pub scopes: Option<Vec<String>>,
 }
 
 impl AuthN {
@@ -85,9 +85,6 @@ impl AuthN {
             "grant_type".to_string(),
             "urn:ietf:params:oauth:grant-type:device_code".to_string(),
         );
-        if let Some(acr_values) = self.acr_values.clone() {
-            form.insert("acr_values".to_string(), acr_values.join(" "));
-        }
         trace!("device_code_form_data: {:?}", form);
         Ok(form)
     }

--- a/src/auth0/types.rs
+++ b/src/auth0/types.rs
@@ -48,9 +48,15 @@ pub struct AuthN {
     pub discovery_uri: Option<String>,
     pub token_preference: Option<AuthToken>,
     pub params: Option<BTreeMap<String, String>>,
+    pub acr_values: Option<Vec<String>>,
+    pub apps_uri: Option<String>,
 }
 
 impl AuthN {
+    pub fn apps_uri(&self) -> Option<String> {
+        return self.apps_uri.clone();
+    }
+
     pub fn login_form_data(&self, scope: &String) -> Result<BTreeMap<String, String>> {
         let mut form = BTreeMap::new();
         form.insert(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -311,7 +311,7 @@ impl P6mEnvironment {
                 let mut auth_n = auth_n.clone();
                 auth_n.apps_uri =
                     Some("https://9b6hcz5ny6.execute-api.us-east-2.amazonaws.com/api".into());
-                auth_n.acr_values = Some(vec!["auth:urn:dev:true".into()]);
+                auth_n.acr_values = Some(vec!["urn:auth:dev:true".into()]);
                 Self {
                     config_dir: config_dir.clone(),
                     kube_dir: home_dir.join(".kube"),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -292,7 +292,6 @@ impl P6mEnvironment {
             false => home_dir.join(".p6m"),
         };
 
-        // TODO: Dev AuthN once we have a dev environment
         let auth_n = AuthN {
             client_id: Some("j4jEhWwe2od1eacxuocy0sfmbf7V4H8V".into()),
             discovery_uri: Some("https://auth.p6m.run/.well-known/openid-configuration".into()),
@@ -301,12 +300,18 @@ impl P6mEnvironment {
                     .into_iter()
                     .collect(),
             ),
+            apps_uri: Some("https://auth.p6m.dev/api".into()),
+            acr_values: None,
             token_preference: Some(AuthToken::Id),
         };
 
         let environment = match dev {
             true => {
                 println!("Using development environment");
+                let mut auth_n = auth_n.clone();
+                auth_n.apps_uri =
+                    Some("https://9b6hcz5ny6.execute-api.us-east-2.amazonaws.com/api".into());
+                auth_n.acr_values = Some(vec!["auth:urn:dev:true".into()]);
                 Self {
                     config_dir: config_dir.clone(),
                     kube_dir: home_dir.join(".kube"),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -301,7 +301,7 @@ impl P6mEnvironment {
                     .collect(),
             ),
             apps_uri: Some("https://auth.p6m.dev/api".into()),
-            acr_values: None,
+            scopes: None,
             token_preference: Some(AuthToken::Id),
         };
 
@@ -311,7 +311,7 @@ impl P6mEnvironment {
                 let mut auth_n = auth_n.clone();
                 auth_n.apps_uri =
                     Some("https://9b6hcz5ny6.execute-api.us-east-2.amazonaws.com/api".into());
-                auth_n.acr_values = Some(vec!["urn:auth:dev:true".into()]);
+                auth_n.scopes = Some(vec!["urn:auth:dev:true".into()]);
                 Self {
                     config_dir: config_dir.clone(),
                     kube_dir: home_dir.join(".kube"),

--- a/src/sso/auth0.rs
+++ b/src/sso/auth0.rs
@@ -41,7 +41,7 @@ pub async fn configure_auth0(
         .email
         .context("missing email")?;
 
-    let client = auth0::Client::new().with_token(id_token);
+    let client = auth0::Client::new(&token_repository.auth_n.apps_uri()).with_token(id_token);
 
     let apps = client.apps().await.context("Unable to fetch apps")?;
 


### PR DESCRIPTION
Related: https://github.com/p6m-run/.platform/pull/10/files

Switches the `apps` URI and adds `acr_values` to include `urn:auth:dev:true` to Device Code and Refresh Token requests