### PR TITLE
ci: pin GitHub Actions runners to explicit versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ env:
 jobs:
   pre-release:
     name: Pre Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.capture.outputs.version }}
     steps:
@@ -72,19 +72,19 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             platform: linux
             arch: x86_64
           - os: ubuntu-24.04-arm
             platform: linux
             arch: arm64
-          - os: macos-latest
+          - os: macos-26
             platform: macos
             arch: arm64
-          - os: macos-13
+          - os: macos-26-intel
             platform: macos
             arch: x86_64
-          - os: windows-latest
+          - os: windows-2025
             platform: windows
             arch: x86_64
 
@@ -205,7 +205,7 @@ jobs:
 
   post-release:
     name: Post Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [pre-release, build]
     env:
       VERSION: v${{ needs.pre-release.outputs.version }}
@@ -223,7 +223,7 @@ jobs:
   update_homebrew_formula:
     name: Update Homebrew Forumula
     needs: [pre-release, build]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       VERSION: v${{ needs.pre-release.outputs.version }}
     steps:


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions runners in `release.yaml` to explicit versions instead of `-latest` tags
- `ubuntu-latest` → `ubuntu-24.04`
- `macos-latest` → `macos-26` (arm64)
- `macos-13` → `macos-26-intel` (x86_64)
- `windows-latest` → `windows-2025`

## Test plan

- [ ] Trigger a release workflow dispatch and verify all matrix builds succeed on the new runners

**Tooling**

| Skills Used | Agents Used |
|-------------|-------------|
| `ybor-standards:git` | Claude Opus 4.6 |
