### PR TITLE
feat: use token-exchange for verified bot commits in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,8 +25,6 @@ env:
   DOWNLOAD_PREFIX: "https://github.com/${{ github.repository }}/releases/download"
   DESTINATION_HOMEBREW_TAP: ${{ github.repository_owner }}/homebrew-tap
   REPOSITORY_DISPATCH_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
-  COMMIT_USER: github-actions
-  COMMIT_EMAIL: github-actions@users.noreply.github.com
 
 jobs:
   pre-release:
@@ -43,12 +41,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: p6m-actions/token-exchange@v2
+
       - name: Bump Version
         if: github.ref == 'refs/heads/main'
         shell: bash
         run: |
-          git config user.name ${{ env.COMMIT_USER }}
-          git config user.email ${{ env.COMMIT_EMAIL }}
           cargo workspaces version ${{ inputs.level }} -y --allow-branch main -m "Release %v [skip ci]" --no-individual-tags --force '*'
 
       - name: Capture Version


### PR DESCRIPTION
## Summary

- Add `p6m-actions/token-exchange@v2` to the pre-release job in the release workflow
- Remove manual `git config` for user name/email — token-exchange handles identity, auth, and verified bot commit signatures
- Remove unused `COMMIT_USER` / `COMMIT_EMAIL` env vars
- Release version bump commits will now show as verified `p6m-ybor[bot]` instead of generic "GitHub Actions"

## Test plan

- [ ] Trigger a release and verify the version bump commit is signed by `p6m-ybor[bot]`
- [ ] Verify `cargo workspaces version` push succeeds with the exchanged token
- [ ] Verify downstream jobs (build, post-release, homebrew update) are unaffected

**Tooling**

| Skills Used | Agents Used |
|-------------|-------------|
| `ybor-standards:git` | Claude Opus 4.6 |
