### PR TITLE
fix: replace stale vcluster kubeconfig entries on update

### DIFF
--- a/src/sso/vcluster.rs
+++ b/src/sso/vcluster.rs
@@ -80,6 +80,13 @@ async fn update_kubeconfig(secret: &Secret) -> Result<String, Error> {
     let server_name =
         uniqueify_kubeconfig(&mut new_kubeconfig).context("couldn't uniqueify kubeconfig")?;
 
+    // kube's merge skips entries whose name already exists, so remove stale
+    // entries first to ensure the secret's values always take effect.
+    let mut kubeconfig = kubeconfig;
+    kubeconfig.clusters.retain(|c| c.name != server_name);
+    kubeconfig.contexts.retain(|c| c.name != server_name);
+    kubeconfig.auth_infos.retain(|a| a.name != server_name);
+
     let kubeconfig = kubeconfig
         .merge(new_kubeconfig)
         .context("unable to merge configs")?;


### PR DESCRIPTION
`Kubeconfig::merge` from the `kube` crate skips entries whose name already exists in the base config. This meant that once a vcluster kubeconfig entry was written to `~/.kube/config`, subsequent updates from the secret (e.g. rotated CA data, client cert, or client key) were silently dropped and the stale values persisted.

This fix removes matching clusters, contexts, and auth_infos from the existing kubeconfig before merging, so the secret's values always take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)